### PR TITLE
Take iowait, steal, guest and guest_nice into account for idle CPU time.

### DIFF
--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -31,6 +31,8 @@ require 'sensu-plugin/check/cli'
 # Check CPU
 #
 class CheckCPU < Sensu::Plugin::Check::CLI
+  CPU_METRICS = [:user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest, :guest_nice]
+
   option :warn,
          short: '-w WARN',
          proc: proc(&:to_f),
@@ -46,7 +48,13 @@ class CheckCPU < Sensu::Plugin::Check::CLI
          proc: proc(&:to_f),
          default: 1
 
-  [:user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest].each do |metric|
+  option :idle_metrics,
+         long: '--idle-metrics METRICS',
+         description: 'Treat the specified metrics as idle. Defaults to idle,iowait,steal,guest,guest_nice',
+         proc: proc { |x| x.split(/,/).map { |y| y.strip.to_sym } },
+         default: [:idle, :iowait, :steal, :guest, :guest_nice]
+
+  CPU_METRICS.each do |metric|
     option metric,
            long: "--#{metric}",
            description: "Check cpu #{metric} instead of total cpu usage",
@@ -63,14 +71,12 @@ class CheckCPU < Sensu::Plugin::Check::CLI
   end
 
   def run
-    metrics = [:user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest]
-
     cpu_stats_before = acquire_cpu_stats
     sleep config[:sleep]
     cpu_stats_after = acquire_cpu_stats
 
-    # Some kernels don't have a 'guest' value (RHEL5).
-    metrics = metrics.slice(0, cpu_stats_after.length)
+    # Some kernels don't have 'guest' and 'guest_nice' values
+    metrics = CPU_METRICS.slice(0, cpu_stats_after.length)
 
     cpu_total_diff = 0.to_f
     cpu_stats_diff = []
@@ -84,7 +90,9 @@ class CheckCPU < Sensu::Plugin::Check::CLI
       cpu_stats[i] = 100 * (cpu_stats_diff[i] / cpu_total_diff)
     end
 
-    cpu_usage = 100 * (cpu_total_diff - cpu_stats_diff[3]) / cpu_total_diff
+    idle_diff = metrics.each_with_index.map { |metric, i| config[:idle_metrics].include?(metric) ? cpu_stats_diff[i] : 0.0 }.reduce(0.0, :+)
+
+    cpu_usage = 100 * (cpu_total_diff - idle_diff) / cpu_total_diff
     checked_usage = cpu_usage
 
     self.class.check_name 'CheckCPU TOTAL'


### PR DESCRIPTION
(Originally posted as https://github.com/sensu/sensu-community-plugins/pull/1253 )

Currently check_cpu plugin only picks `idle` as a metric of CPU idle time, but this doesn't always give desired results.  At least `iowait` needs to be included there considering the purpose of this plugin.  Besides, `steal`, `guest` and `guest_nice` should be taken into account because they are involuntary time consumption outside the VM.

This patch adds `guest_nice` to the line-ups of metrics, which has been available in Linux since 2.6.33.

This patch also adds a new option `--idle-metrics` whose value specifies the names of the metrics that are included in the calculation of CPU idle time as a comma-separated string.  The value defaults to `idle,iowait,steal,guest,guest_nice`
