### PR TITLE
Add metrics-numastat.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - modify check-cpu.rb to change state if >= threshold 
 
+### Added
+- add metrics-numastat.rb
+
 ## [0.0.4] - 2015-09-29
 ### Changed
 - Fix getopts syntax in check-cpu.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
  * bin/check-cpu.sh
  * bin/metrics-cpu-mpstat.rb
  * bin/metrics-cpu-pcnt-usage.rb
+ * bin/metrics-numastat.rb
  * bin/metrics-user-pct-usage.rb
 
 ## Usage

--- a/bin/metrics-numastat.rb
+++ b/bin/metrics-numastat.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+#
+#   metrics-numastat
+#
+# DESCRIPTION:
+#   Simple wrapper around `numastat` for getting per-NUMA-node memory stats.
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2016 Mitsutoshi Aoe
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'socket'
+require 'sensu-plugin/metric/cli'
+
+class NumastatMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.numastat"
+
+  def run
+    begin
+      output = `/usr/bin/numastat`
+    rescue Errno::ENOENT => err
+      unknown err
+    end
+
+    nodes = []
+    output.each_line do |line|
+      nodes = line.split(' ') if nodes.empty?
+      next unless /^([^\s]+)\s+(.+)$/ =~ line
+      key = Regexp.last_match[1]
+      vals = Regexp.last_match[2]
+      next if key.nil? || vals.nil?
+      nodes.zip(vals.split(' ')).each do |node, val|
+        output "#{config[:scheme]}.#{node}.#{key}", val
+      end
+    end
+
+    ok
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### New Plugins
- [x] Tests
- [x] Add the plugin to the README
- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

This plugin is a wrapper around the `numastat` command.

```
% /opt/sensu/embedded/bin/ruby ./metrics-numastat.rb -s numastat
numastat.node0.numa_hit 70109703 1459233325
numastat.node1.numa_hit 71051265 1459233325
numastat.node0.numa_miss 0 1459233325
numastat.node1.numa_miss 0 1459233325
numastat.node0.numa_foreign 0 1459233325
numastat.node1.numa_foreign 0 1459233325
numastat.node0.interleave_hit 21142 1459233325
numastat.node1.interleave_hit 22049 1459233325
numastat.node0.local_node 70101065 1459233325
numastat.node1.local_node 71037602 1459233325
numastat.node0.other_node 8638 1459233325
numastat.node1.other_node 13663 1459233325
```
#### Known Compatablity Issues

I've tested this on Ubuntu Trusty. No known issues so far.
