### PR TITLE
Remove Ruby 1.9.3 support; add Ruby 2.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-cpu-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,17 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- modify check-cpu.rb to change state if >= threshold
+- Modified check-cpu.rb to change state if >= threshold
+- Updated Rubocop to 0.40, applied auto-correct
+- Loosened sensu-plugin dependency to ~> 1.2
+- Specify the /proc location for use within a container
 
 ### Added
-- add metrics-numastat.rb
+- Added metrics-numastat.rb
+- check-cpu.rb: Added --idle-metrics flag for indicating counters which should be considered idle
 
 ### Removed
 - Remove Ruby 1.9.3 support; add Ruby 2.3.0 support in test matrix
-
-## [0.0.5] - 2016-06-01
-### Changed
-- Specify the /proc location for use within a container
 
 ## [0.0.4] - 2015-09-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Changed
-- modify check-cpu.rb to change state if >= threshold 
+- modify check-cpu.rb to change state if >= threshold
 
 ### Added
 - add metrics-numastat.rb
+
+### Removed
+- Remove Ruby 1.9.3 support; add Ruby 2.3.0 support in test matrix
 
 ## [0.0.5] - 2016-06-01
 ### Changed

--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,8 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
+
+args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze

--- a/sensu-plugins-cpu-checks.gemspec
+++ b/sensu-plugins-cpu-checks.gemspec
@@ -2,14 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-cpu-checks'
-else
-  require_relative 'lib/sensu-plugins-cpu-checks'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-cpu-checks'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu Plugins and contributors']
@@ -32,7 +25,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for cpu checks and metrics'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes Ruby 1.9.3 support, and adds support for testing under Ruby 2.3.0, per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
