### PR TITLE
Add alternative caching method to acquire CPU data

### DIFF
--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -92,7 +92,7 @@ class CheckCPU < Sensu::Plugin::Check::CLI
     before = JSON.parse(File.read(config[:cache_file]))
     now = acquire_cpu_stats
 
-    [before, now, Time.now.to_i - File.mtime(config[:cache_file]).to_i]
+    [before, now]
   end
 
   def write_stats_to_cache_file(data)
@@ -101,19 +101,18 @@ class CheckCPU < Sensu::Plugin::Check::CLI
 
   def acquire_stats(sec)
     if config[:cache_file] && File.exist?(config[:cache_file])
-      (before, now, sec) = acquire_stats_with_cache_file
+      (before, now) = acquire_stats_with_cache_file
     else
       (before, now) = acquire_stats_with_sleeping(sec)
     end
-    if (config[:cache_file])
-      write_stats_to_cache_file(now)
-    end
 
-    return [before, now, sec]
+    write_stats_to_cache_file(now) if config[:cache_file]
+
+    [before, now]
   end
 
   def run
-    (cpu_stats_before, cpu_stats_now, sec) = acquire_stats(config[:sleep])
+    (cpu_stats_before, cpu_stats_now) = acquire_stats(config[:sleep])
 
     # Some kernels don't have 'guest' and 'guest_nice' values
     metrics = CPU_METRICS.slice(0, cpu_stats_now.length)

--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -31,7 +31,7 @@ require 'json'
 #
 # Check CPU
 #
-class CheckCPUNew < Sensu::Plugin::Check::CLI
+class CheckCPU < Sensu::Plugin::Check::CLI
   CPU_METRICS = [:user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest, :guest_nice].freeze
 
   option :warn,


### PR DESCRIPTION
This enables to set a cache file that will be used to save the last execution of the acuire_cpu_stats, removing the need for sleeping for a period of time to get accurate results.
At the next check execution, the acquired cpu data is compared to the cached file, thus the effective period of time is the same as the check interval.

Sleeping causes problems when restarting the sensu-client, if the sleep time is over 10 seconds (the timeout to wait for the service to stop).

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

