### PR TITLE
Correctly set type for --proc-path long option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [1.0.1] - 2017-05-02
+## 2017-05-02
 ### Fixed
 - Set the correct type for --proc-path
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [1.0.1] - 2017-05-02
+### Fixed
+- Set the correct type for --proc-path
+
 ## [1.0.0] - 2016-06-15
 ### Changed
 - Modified check-cpu.rb to change state if >= threshold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## 2017-05-02
 ### Fixed
 - Set the correct type for --proc-path
 

--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -62,7 +62,7 @@ class CheckCPU < Sensu::Plugin::Check::CLI
 
   option :proc_path,
          long: '--proc-path /proc',
-         proc: proc(&:to_f),
+         proc: proc(&:to_s),
          default: '/proc'
 
   option :idle_metrics,

--- a/lib/sensu-plugins-cpu-checks/version.rb
+++ b/lib/sensu-plugins-cpu-checks/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsCpuChecks
   module Version
     MAJOR = 1
     MINOR = 0
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-cpu-checks/version.rb
+++ b/lib/sensu-plugins-cpu-checks/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsCpuChecks
   module Version
     MAJOR = 1
     MINOR = 0
-    PATCH = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
* Bugfix: correctly set type for --proc-path long option; should be a… string, not a float
* Bump version number and add CHANGELOG entry

## Pull Request Checklist
#23

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [N/A] Update README with any necessary configuration snippets

- [N/A] Binstubs are created if needed

- [x] RuboCop passes

- [N/A] Existing tests pass 

#### New Plugins

- [N/A] Tests

- [N/A] Add the plugin to the README

- [N/A] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues
None
