### PR TITLE
loosten gem pin on sensu-plugin to support 1.2-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## Changed
+- loostened gemspec requirements on sensu-plugin to 1.2-2.0
+
 ## [1.1.0] - 2017-05-02
 ### Changed
 - no real change just bumping due to deployment issue.

--- a/sensu-plugins-cpu-checks.gemspec
+++ b/sensu-plugins-cpu-checks.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsCpuChecks::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', ['>= 1.2', '< 2.0']
   s.add_runtime_dependency 'linux-kstat',  '0.1.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

https://github.com/sensu-plugins/sensu-plugins-elasticsearch/issues/71

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Loosen Gem deps to allow multiple versions of sensu-plugin to be installed.
#### Known Compatablity Issues
None
