### PR TITLE
correctly set type for --proc-path long option in metrics plugins

### DIFF
--- a/bin/metrics-cpu-pcnt-usage.rb
+++ b/bin/metrics-cpu-pcnt-usage.rb
@@ -38,7 +38,7 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :proc_path,
          long: '--proc-path /proc',
-         proc: proc(&:to_f),
+         proc: proc(&:to_s),
          default: '/proc'
 
   def acquire_proc_stats

--- a/bin/metrics-cpu.rb
+++ b/bin/metrics-cpu.rb
@@ -38,7 +38,7 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :proc_path,
          long: '--proc-path /proc',
-         proc: proc(&:to_f),
+         proc: proc(&:to_s),
          default: '/proc'
 
   def run


### PR DESCRIPTION
Fixes #23 for metrics plugins.