### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Changed
+- appeased the cops (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
 ## [1.1.3] - 2018-01-25
 ### Added
 - ruby 2.4 testing (@majormoses)

--- a/Rakefile
+++ b/Rakefile
@@ -8,12 +8,12 @@ require 'yard/rake/yardoc_task'
 
 desc 'Don\'t run Rubocop for unsupported versions'
 
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new

--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -32,7 +32,7 @@ require 'json'
 # Check CPU
 #
 class CheckCPU < Sensu::Plugin::Check::CLI
-  CPU_METRICS = [:user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest, :guest_nice].freeze
+  CPU_METRICS = %i[user nice system idle iowait irq softirq steal guest guest_nice].freeze
 
   option :less_than,
          description: 'Change whether value is less than check',
@@ -69,7 +69,7 @@ class CheckCPU < Sensu::Plugin::Check::CLI
          long: '--idle-metrics METRICS',
          description: 'Treat the specified metrics as idle. Defaults to idle,iowait,steal,guest,guest_nice',
          proc: proc { |x| x.split(/,/).map { |y| y.strip.to_sym } },
-         default: [:idle, :iowait, :steal, :guest, :guest_nice]
+         default: %i[idle iowait steal guest guest_nice]
 
   CPU_METRICS.each do |metric|
     option metric,

--- a/bin/metrics-cpu-mpstat.rb
+++ b/bin/metrics-cpu-mpstat.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   cpu-mpstat-metrics
 #

--- a/bin/metrics-cpu-pcnt-usage.rb
+++ b/bin/metrics-cpu-pcnt-usage.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   cpu-pct-usage-metrics
 #
@@ -42,7 +41,7 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: '/proc'
 
   def acquire_proc_stats
-    cpu_metrics = %w(user nice system idle iowait irq softirq steal guest)
+    cpu_metrics = %w[user nice system idle iowait irq softirq steal guest]
     File.open("#{config[:proc_path]}/stat", 'r').each_line do |line|
       info = line.split(/\s+/)
       next if info.empty?
@@ -59,7 +58,7 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def sum_cpu_metrics(metrics)
     # #YELLOW
-    metrics.values.reduce { |sum, metric| sum + metric } # rubocop:disable SingleLineBlockParams
+    metrics.values.reduce { |sum, metric| sum + metric }
   end
 
   def run

--- a/bin/metrics-cpu.rb
+++ b/bin/metrics-cpu.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #   cpu-metrics
 #
@@ -42,8 +41,8 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: '/proc'
 
   def run
-    cpu_metrics = %w(user nice system idle iowait irq softirq steal guest guest_nice)
-    other_metrics = %w(ctxt processes procs_running procs_blocked btime intr)
+    cpu_metrics = %w[user nice system idle iowait irq softirq steal guest guest_nice]
+    other_metrics = %w[ctxt processes procs_running procs_blocked btime intr]
     cpu_count = 0
 
     File.open("#{config[:proc_path]}/stat", 'r').each_line do |line|

--- a/bin/metrics-user-pct-usage.rb
+++ b/bin/metrics-user-pct-usage.rb
@@ -66,7 +66,7 @@ class UserPercent < Sensu::Plugin::Metric::CLI::Graphite
     end
 
     if config[:ignore_inactive]
-      users.delete_if { |_key, value| value['cpu'] == 0 }
+      users.delete_if { |_key, value| value['cpu'].zero? }
     end
 
     users.each do |user, h|

--- a/sensu-plugins-cpu-checks.gemspec
+++ b/sensu-plugins-cpu-checks.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-cpu-checks'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu Plugins and contributors']
   # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                               CPU usage and metrics'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-cpu-checks'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '@mattyjones',
@@ -25,13 +25,14 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for cpu checks and metrics'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsCpuChecks::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+
   s.add_runtime_dependency 'linux-kstat',  '0.1.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
@@ -40,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Address CVE, see parent issue for details

#### Known Compatibility Issues
Removes ruby `< 2.1` support