### PR TITLE
[BREAKING CHANGES] update default `sleep` for `check-cpu.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Breaking Changes
+- changing the default of `--sleep` from `1` to `5` this argument controls the time between initial poll and the followup poll which will get more overall accurate measurement of cpu utilization especially on systems that have less resources available (@majormoses)
+
 ## [2.1.0] - 2018-04-2018
 ### Added
 - Added metrics-cpu-interrupts.rb (@yuri-zubov sponsored by Actility, https://www.actility.com)

--- a/bin/check-cpu.rb
+++ b/bin/check-cpu.rb
@@ -53,8 +53,9 @@ class CheckCPU < Sensu::Plugin::Check::CLI
 
   option :sleep,
          long: '--sleep SLEEP',
+         description: 'This sleep controls the interval between the initial poll for cpu utilization and the next data point, the longer the interval is the more accurate your data will be', # rubocop:disable Metrics/LineLength
          proc: proc(&:to_f),
-         default: 1
+         default: 5
 
   option :cache_file,
          long: '--cache-file CACHEFILE',


### PR DESCRIPTION
The goal behind this is to provide overall more accurate CPU utilization results. The way we calculate this is to pull the current utilization, sleep `n` seconds, poll again, and then take a difference between the two numbers. From my tests at my last organization I found that increasing the sleep time gave more accurate overall results. There are several reasons for this but the main reason is that by the very act of calling up the ruby interpreter you are incuring additional cpu utilization. By increasing the poll interval you allow its utilization to even out from the initial load of the interpreter. `5` is by no means a magic number but I found at my previous employer that `5` was a very reasonable compromise for accuracy and still being able to schedule it to see very granular results. The more resource contrained the machine is the more value you will get out of higher sleep/poll values.

This is a breaking change as it updates the defaults and if you are scheduling this more frequently than 10 seconds (and do not set your own sleep value) you could very easily end up with multiple instances of the same check running which would only increase the problem.

From my tests locally I did not notice much difference (about 2-3% inflated) between the data returned from this check and `top -d 5` values

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

closes #35 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


Test:
```
$ bundle exec ./bin/check-cpu.rb 
CheckCPU TOTAL OK: total=17.51 user=14.21 nice=0.0 system=3.12 idle=82.46 iowait=0.03 irq=0.0 softirq=0.18 steal=0.0 guest=0.0 guest_nice=0.0
```

#### Purpose
Provide a better default that produces smoother metric utilization picture by increasing the poll interval

#### Known Compatibility Issues
This changes the default poll/sleep value from `1` to `5` if you are scheduling your checks more often than 5 seconds this could make the problem even worst as they could start overlapping because of the scheduling. I find that most people I have seen are checking no more than once every 10 seconds and for those people they should be able to upgrade safely without modification.