### PR TITLE
Move to platform_family from platform

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -8,7 +8,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'debian'"
+  -  "entity.system.platform_family == 'debian'"
 - platform: "centos"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_centos_linux_amd64.tar.gz"
@@ -16,7 +16,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'rhel'"
+  -  "entity.system.platform_family == 'rhel'"
 - platform: "alpine"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_alpine_linux_amd64.tar.gz"
@@ -24,5 +24,5 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'alpine'"
+  -  "entity.system.platform_family == 'alpine'"
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass


#### Purpose
I have transitions the bonsai filters from using platform to platform_family. I believe this was the intended effect for the filters as the platform for `centos` is `centos` not `rhel` but that is the platform_family. I believe this should also be the case for debian as it should support ubuntu as well.

I did not update the changelog as this really doesn't impact the package just the bonsai component. 

#### Known Compatibility Issues
